### PR TITLE
[fix] supporting slash in text

### DIFF
--- a/deepl_tr_pp/deepl_tr_pp.py
+++ b/deepl_tr_pp/deepl_tr_pp.py
@@ -208,7 +208,8 @@ async def deepl_tr_pp(  # noqa: C901
         text = text[:5000]
         logger.warning(" text length (%s) > 5000, trimming to 5000", len(text))
 
-    url_ = f"{URL}#{from_lang}/{to_lang}/{quote(text)}"
+    urltext = quote(text).replace("/","%5C%2F")
+    url_ = f"{URL}#{from_lang}/{to_lang}/{urltext}"
 
     count = 0
     while count < 3:


### PR DESCRIPTION
Text for testing:

`deepl-tr-pp --copyfrom`
```html
<p class="indent"><em class="calibre5">Born:</em> June 15, 1916, Milwaukee, Wisconsin, in a rented flat, but soon (1918) moved with his family to a modest frame house owned by his parents in a middle-class neighborhood of the West (that is, the German) Side.</p><p>1001</p>
```